### PR TITLE
Switch from esm to @httptoolkit/esm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
-        "esm": "^3.2.25"
+        "@httptoolkit/esm": "^3.3.0"
       },
       "devDependencies": {
         "@types/esm": "^3.2.2",
@@ -773,6 +773,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@httptoolkit/esm": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/esm/-/esm-3.3.0.tgz",
+      "integrity": "sha512-gS+TH14750cveYP5p2q/oLyjVV5+qRFZMOpsPzK1KrgacqKc6RLDmt3ioGaMjsn1aianQbROkl4QXDJmO5swPA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2562,14 +2570,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
-    "esm": "^3.2.25"
+    "@httptoolkit/esm": "^3.3.0"
   }
 }

--- a/src/httptoolkit-esm-types.d.ts
+++ b/src/httptoolkit-esm-types.d.ts
@@ -1,0 +1,4 @@
+declare module '@httptoolkit/esm' {
+    import * as Esm from 'esm';
+    export = Esm;
+}

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,5 +1,6 @@
-import esm from 'esm';
+import esm from '@httptoolkit/esm';
 import fs from 'fs';
+
 import { ESMOptions, Options } from './types';
 import { findModuleFile, getCallerDirname } from './files';
 

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,5 +1,4 @@
 import esm from '@httptoolkit/esm';
-import fs from 'fs';
 
 import { ESMOptions, Options } from './types';
 import { findModuleFile, getCallerDirname } from './files';
@@ -11,27 +10,7 @@ import { findModuleFile, getCallerDirname } from './files';
  */
 /* istanbul ignore next */
 const createEsmRequire = (esmOptions: ESMOptions) => {
-  /**
-   * Removes the error for "[ERR_REQUIRE_ESM]: require() of ES Module", as per
-   * - https://github.com/standard-things/esm/issues/855#issuecomment-657982788
-   */
-  require('module').Module._extensions['.js'] = (m: any, filename: string) => {
-    m._compile(fs.readFileSync(filename, 'utf-8'), filename);
-  };
-  const loader = esm(module, esmOptions);
-
-  const newModule = module.constructor.length > 1 ? module.constructor : loader('module');
-  const oldResolveFilename = newModule._resolveFilename;
-  /**
-   * Referencing
-   * - https://github.com/kenotron/esm-jest/commit/624b9524ee698f5cbd16ee2481dc4cd0dec52e42
-   * - https://github.com/standard-things/esm/issues/331#issuecomment-377056717
-   */
-  newModule._resolveFilename = function(request: string, parent: any, isMain: boolean) {
-    const newRequest = request.startsWith('node:') ? request.substring(5) : request;
-    return oldResolveFilename.call(this, newRequest, parent, isMain);
-  };
-  return loader;
+  return esm(module, esmOptions);
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import esm from 'esm';
+import esm from '@httptoolkit/esm';
 
 export type ESMOptions = Parameters<typeof esm>[1];
 


### PR DESCRIPTION
Fixes #37. I've just reused the @types/esm types here, since they should be the same and I haven't worked out how to modify esm to add them in easily directly over there (the build & publish setup is much more complicated than you'd expect).

This change also removes workarounds here that I think were since fixed within esm-wallaby ([here](https://github.com/httptoolkit/esm/commit/88a276802d6f9fd799ebd0771ef98b27ad585fcd) and [here](https://github.com/httptoolkit/esm/commit/62e08358faa0e071d78ea7963aab762017ac3615) specifically).

I don't have any specific interesting test cases to confirm those, but I can do things like `require('.')('node:fs')` with no problem, and everything works correctly for other modules, so I assume that's all working nicely now.