### PR TITLE
Switched to the newly published @types/httptoolkit__esm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.1.0",
         "@commitlint/config-conventional": "^19.1.0",
-        "@types/esm": "^3.2.2",
+        "@types/httptoolkit__esm": "^3.3.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.26",
         "@typescript-eslint/eslint-plugin": "^7.2.0",
@@ -2044,19 +2044,19 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/esm": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/esm/-/esm-3.2.2.tgz",
-      "integrity": "sha512-l3IQQD2sChjNiQVNf28qq+sY9Sjvz7HrcOO3g4ZeSaiQRXQccBaR6cpqXPpzJ3QYCt6UF7+4ugabMRsQTPV+Eg==",
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
+      "integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
     },
-    "node_modules/@types/graceful-fs": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
-      "integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
+    "node_modules/@types/httptoolkit__esm": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/httptoolkit__esm/-/httptoolkit__esm-3.3.0.tgz",
+      "integrity": "sha512-d8KultwVozybFoaEdjDWA0s0XKkw75MRELG7RbJdCeAKmhvKlz5uIfeGNZzsHATuPY7JKyklo7zPEPBKxGt7TQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "import-sync",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "import-sync",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
         "@httptoolkit/esm": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   },
   "version": "2.2.1",
   "files": [
-    "dist",
-    "types"
+    "dist"
   ],
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -45,7 +44,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.1.0",
     "@commitlint/config-conventional": "^19.1.0",
-    "@types/esm": "^3.2.2",
+    "@types/httptoolkit__esm": "^3.3.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.26",
     "@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "type": "git",
     "url": "https://github.com/nktnet1/import-sync"
   },
-  "version": "2.2.1",
+  "version": "2.2.2",
   "files": [
     "dist"
   ],

--- a/types/httptoolkit-esm-types.d.ts
+++ b/types/httptoolkit-esm-types.d.ts
@@ -1,4 +1,0 @@
-declare module '@httptoolkit/esm' {
-  import Esm from 'esm';
-  export = Esm;
-}


### PR DESCRIPTION
@pimterry follow up regarding "types" in #38.

I managed to get the types for @httptoolkit/esm published here:
- https://www.npmjs.com/package/@types/httptoolkit__esm

Context: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68976 

The type definition for @httptoolkit/esm can thus be removed from import-sync.

This MR is an improvement to the solution in #81 to fix #79.

---

Also, given that the original [esm](https://github.com/standard-things/esm) repository has been archived, do you think it's a good idea to enable issues for the [@httptoolkit/esm](https://github.com/httptoolkit/esm) fork? (e.g. by following the instructions [here](https://stackoverflow.com/a/16406283/22324694)).

