### PR TITLE
feat: bump esm-sync, supporting ES2022 arbitrary module namespace identifiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "esm-sync": "3.3.4"
+    "esm-sync": "3.3.5"
   },
   "packageManager": "pnpm@10.33.0",
   "main": "./dist/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
   .:
     dependencies:
       esm-sync:
-        specifier: 3.3.4
-        version: 3.3.4
+        specifier: 3.3.5
+        version: 3.3.5
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.5.0
@@ -1484,8 +1484,8 @@ packages:
       jiti:
         optional: true
 
-  esm-sync@3.3.4:
-    resolution: {integrity: sha512-sREHsPB/7OIQiI0u8rTYC+rYpxj5K9aIGN6NwOmuZR2QixINAXDEIuvwUwRdtI24FBpwnk/60aSujeDtp/f9Yg==}
+  esm-sync@3.3.5:
+    resolution: {integrity: sha512-ULAGe0/+AQWvaxLE41QLIZbld+6nyxf+p52dr7GUbSTcZjjMe/D6iafZ3GIx6PJiVXlJtVAKzIN7+SiskMYDGQ==}
     engines: {node: '>=6'}
 
   espree@10.4.0:
@@ -4542,7 +4542,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  esm-sync@3.3.4:
+  esm-sync@3.3.5:
     dependencies:
       punycode: 2.3.1
 

--- a/tests/edge/edge.test.ts
+++ b/tests/edge/edge.test.ts
@@ -16,6 +16,7 @@ test('Literal alias', () => {
     'module.exports': 1531,
     myVarAlias: 1531,
     '  __  :)  __  ': 1531,
+    ' 😆 ': 1531,
   });
 });
 

--- a/tests/edge/edge.test.ts
+++ b/tests/edge/edge.test.ts
@@ -9,6 +9,16 @@ test('Broken file', () => {
   expect(() => importSync('./broken')).toThrow(Error);
 });
 
+test('Literal alias', () => {
+  expect(importSync('./literal-alias')).toMatchObject({
+    myVar: 1531,
+    default: 1531,
+    'module.exports': 1531,
+    myVarAlias: 1531,
+    '  __  :)  __  ': 1531,
+  });
+});
+
 test.each([
   { extension: '', message: 'JavaScript' },
   { extension: '.js', message: 'JavaScript' },

--- a/tests/edge/literal-alias.js
+++ b/tests/edge/literal-alias.js
@@ -1,0 +1,8 @@
+export const myVar = 1531;
+
+export {
+  myVar as default,
+  myVar as 'module.exports',
+  myVar as 'myVarAlias',
+  myVar as '  __  :)  __  ',
+};

--- a/tests/edge/literal-alias.js
+++ b/tests/edge/literal-alias.js
@@ -1,8 +1,10 @@
 export const myVar = 1531;
 
 export {
-  myVar as default,
   myVar as 'module.exports',
   myVar as 'myVarAlias',
   myVar as '  __  :)  __  ',
+  myVar as ' 😆 ',
 };
+
+export default myVar;


### PR DESCRIPTION
Resolves #139.